### PR TITLE
add command to run expo with clear cache

### DIFF
--- a/src/athena/package.json
+++ b/src/athena/package.json
@@ -4,6 +4,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
+    "start-clear": "expo start -c",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
Provides a solution for #98, where you can run `npm run start-clear` if you've made a change to the `.env`. We don't want to do this every time, because clearing the cache needlessly will increase build time.
