### PR TITLE
React/horizontal card scroller

### DIFF
--- a/src/athena/src/components/containers/HorizontalCardScroller.tsx
+++ b/src/athena/src/components/containers/HorizontalCardScroller.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from 'react';
+import { SafeAreaView, ScrollView, View, ViewProps, Text } from 'react-native';
+import theme from '../../theme';
+import { Card } from './Card';
+
+interface HorizontalCardScrollerProps {
+  children: ReactNode[] | ReactNode;
+  styles?: ViewProps['style'];
+  showScrollBar?: boolean;
+}
+
+export const HorizontalCardScroller: React.FC<HorizontalCardScrollerProps> = ({
+  styles,
+  children,
+  showScrollBar = false,
+}) => {
+  return (
+    <ScrollView horizontal={true} showsHorizontalScrollIndicator={showScrollBar} style={styles}>
+      {children}
+    </ScrollView>
+  );
+};

--- a/src/athena/src/components/containers/HorizontalCardScroller.tsx
+++ b/src/athena/src/components/containers/HorizontalCardScroller.tsx
@@ -1,7 +1,5 @@
 import React, { ReactNode } from 'react';
-import { SafeAreaView, ScrollView, View, ViewProps, Text } from 'react-native';
-import theme from '../../theme';
-import { Card } from './Card';
+import { ScrollView, ViewProps } from 'react-native';
 
 interface HorizontalCardScrollerProps {
   children: ReactNode[] | ReactNode;


### PR DESCRIPTION
#### Related Issue Link:
145

### Usage
```
  <HorizontalCardScroller showScrollBar={true}>
    <Card> 1 </Card>
    <Card> 2 </Card>
    <Card> 3 </Card>
    <Card> 4 </Card>
    <Card> 5 </Card>
    <Card> 6 </Card>
    <Card> 7 </Card>
    <Card> 8 </Card>
    <Card> 9 </Card>
    <Card> 10 </Card>
  </HorizontalCardScroller>
```
scrollbar is off by default
