### PR TITLE
115 input text width bug

### DIFF
--- a/src/athena/src/components/elements/Input.tsx
+++ b/src/athena/src/components/elements/Input.tsx
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
   },
   input: {
     padding: 13,
-    height: '100%',
+    flex: 1,
     borderRadius: 18,
     zIndex: 10,
     fontWeight: '300',


### PR DESCRIPTION
#### Related Issue Link: #115 

#### Figma Link: N/A

#### Prerequisite PR(s): N/A

This is the icon itself is not part of the input field, but I think this is okay. Much easier to use naturally. Also allows password fields to actually fill the whole box instead of doing that wierd ... thing
